### PR TITLE
fix(render_events): drive dials only, bake settings into the render graph

### DIFF
--- a/hum/event_params.py
+++ b/hum/event_params.py
@@ -1,0 +1,211 @@
+"""Partition a recorded control-event stream into dials and settings.
+
+A ``Synth`` records *every* parameter it knows about: its first recorded event is
+a full snapshot of the initial state, so a recording always mentions the
+*settings* (structural, non-live parameters such as a waveform name) alongside
+the *dials* (live, continuously-controllable parameters such as a frequency).
+
+When such a recording is rendered offline, only the dials may be driven by a
+control signal. Wrapping a setting in one hands the synth function a signal
+object where it expected a plain value -- a synth that uses a setting as a dict
+key then fails with ``TypeError: unhashable type``, and one that merely compares
+it misbehaves silently.
+
+:func:`plan_render_params` computes that split. It is deliberately free of any
+``pyo`` import so the rule can be reasoned about -- and tested -- without the
+optional audio engine installed.
+"""
+
+from typing import (
+    Any,
+    Dict,
+    FrozenSet,
+    Iterable,
+    List,
+    Mapping,
+    NamedTuple,
+    Sequence,
+    Tuple,
+)
+from warnings import warn
+
+__all__ = ["RenderParamPlan", "RenderParamWarning", "plan_render_params"]
+
+
+ControlEvent = Tuple[float, Dict[str, Any]]
+
+
+class RenderParamWarning(UserWarning):
+    """Raised (as a warning) when a recorded event cannot be honored on render."""
+
+
+class RenderParamPlan(NamedTuple):
+    """How a recorded control-event stream maps onto a single render graph.
+
+    Attributes
+    ----------
+    dial_keys : frozenset of str
+        The dials actually mentioned by the recording. These -- and only these --
+        get a live control signal.
+    settings_values : dict
+        Settings values baked into the graph at build time.
+    dial_events : list of (float, dict)
+        The event stream with every non-dial key removed. Timestamps and event
+        count are preserved (an event may become empty), so render timing is
+        unaffected by the filtering.
+    ignored_settings_changes : list of (float, dict)
+        Settings changes that appeared *after* the initial snapshot and were
+        dropped. A single offline graph cannot express the rebuild they need.
+    unknown_keys : frozenset of str
+        Recorded keys that are neither a dial nor a setting; also dropped.
+    """
+
+    dial_keys: FrozenSet[str]
+    settings_values: Dict[str, Any]
+    dial_events: List[ControlEvent]
+    ignored_settings_changes: List[ControlEvent]
+    unknown_keys: FrozenSet[str]
+
+
+def plan_render_params(
+    control_events: Sequence[ControlEvent],
+    *,
+    dials: Iterable[str],
+    settings: Iterable[str],
+    settings_defaults: Mapping[str, Any] = None,
+    warn_on_ignored: bool = True,
+) -> RenderParamPlan:
+    """Split a recorded control-event stream into dials to drive and settings to bake.
+
+    Settings are taken from the recording's *initial snapshot* (its first event),
+    falling back to ``settings_defaults`` for any setting the recording never
+    mentions. Settings changes later in the stream are dropped with a warning:
+    honoring one would require rebuilding the synthesis graph mid-render, which a
+    single offline render cannot express. (This mirrors the live path, where such
+    a change rebuilds the graph.)
+
+    Parameters
+    ----------
+    control_events : sequence of (timestamp, updates)
+        The recorded stream, oldest first.
+    dials : iterable of str
+        Names of the live parameters.
+    settings : iterable of str
+        Names of the structural parameters.
+    settings_defaults : mapping, optional
+        Fallback values for settings absent from the recording -- typically the
+        synth function's own parameter defaults.
+    warn_on_ignored : bool
+        Whether to emit :class:`RenderParamWarning` for dropped keys.
+
+    Returns
+    -------
+    RenderParamPlan
+
+    Examples
+    --------
+    A recording of one dial (``freq``) and one setting (``waveform``). The
+    setting is baked from the initial snapshot, never wrapped as a dial:
+
+    >>> events = [(0.0, {'freq': 440, 'waveform': 'sine'}), (1.0, {'freq': 660})]
+    >>> plan = plan_render_params(events, dials={'freq'}, settings={'waveform'})
+    >>> sorted(plan.dial_keys)
+    ['freq']
+    >>> plan.settings_values
+    {'waveform': 'sine'}
+    >>> plan.dial_events
+    [(0.0, {'freq': 440}), (1.0, {'freq': 660})]
+
+    A setting the recording never mentions falls back to its default:
+
+    >>> plan = plan_render_params(
+    ...     [(0.0, {'freq': 440})],
+    ...     dials={'freq'},
+    ...     settings={'waveform'},
+    ...     settings_defaults={'freq': 440, 'waveform': 'sine'},
+    ... )
+    >>> plan.settings_values
+    {'waveform': 'sine'}
+
+    A settings change *after* the initial snapshot is dropped (with a warning),
+    and the event keeps its slot so the render timing does not shift:
+
+    >>> import warnings
+    >>> with warnings.catch_warnings(record=True) as caught:
+    ...     warnings.simplefilter('always')
+    ...     plan = plan_render_params(
+    ...         [(0.0, {'freq': 440, 'waveform': 'sine'}), (1.0, {'waveform': 'square'})],
+    ...         dials={'freq'},
+    ...         settings={'waveform'},
+    ...     )
+    >>> plan.settings_values
+    {'waveform': 'sine'}
+    >>> plan.dial_events
+    [(0.0, {'freq': 440}), (1.0, {})]
+    >>> plan.ignored_settings_changes
+    [(1.0, {'waveform': 'square'})]
+    >>> len(caught), issubclass(caught[0].category, RenderParamWarning)
+    (1, True)
+    """
+    dials, settings = frozenset(dials), frozenset(settings)
+    settings_defaults = settings_defaults or {}
+
+    recorded_keys = {k for _, updates in control_events for k in updates}
+    dial_keys = recorded_keys & dials
+    unknown_keys = recorded_keys - dials - settings
+
+    initial_snapshot = control_events[0][1] if control_events else {}
+    settings_values = {
+        k: initial_snapshot[k] if k in initial_snapshot else settings_defaults[k]
+        for k in sorted(settings)
+        if k in initial_snapshot or k in settings_defaults
+    }
+
+    dial_events = [
+        (t, {k: v for k, v in updates.items() if k in dial_keys})
+        for t, updates in control_events
+    ]
+    ignored_settings_changes = [
+        (t, ignored)
+        for t, updates in control_events[1:]
+        if (ignored := {k: v for k, v in updates.items() if k in settings})
+    ]
+
+    if warn_on_ignored:
+        _warn_about_dropped_keys(ignored_settings_changes, unknown_keys)
+
+    return RenderParamPlan(
+        dial_keys=frozenset(dial_keys),
+        settings_values=settings_values,
+        dial_events=dial_events,
+        ignored_settings_changes=ignored_settings_changes,
+        unknown_keys=frozenset(unknown_keys),
+    )
+
+
+def _warn_about_dropped_keys(
+    ignored_settings_changes: Sequence[ControlEvent],
+    unknown_keys: Iterable[str],
+) -> None:
+    """Warn about recorded keys that the render cannot honor."""
+    if ignored_settings_changes:
+        changed = sorted(
+            {k for _, updates in ignored_settings_changes for k in updates}
+        )
+        warn(
+            f"Ignoring {len(ignored_settings_changes)} mid-stream change(s) to "
+            f"settings {changed}: a single offline render builds one synthesis "
+            f"graph, so only the settings of the initial snapshot are honored. "
+            f"Split the recording and render each segment separately if you need "
+            f"the change.",
+            RenderParamWarning,
+            stacklevel=3,
+        )
+    unknown_keys = sorted(unknown_keys)
+    if unknown_keys:
+        warn(
+            f"Ignoring recorded key(s) {unknown_keys}: they are neither a dial "
+            f"nor a setting of the synth function.",
+            RenderParamWarning,
+            stacklevel=3,
+        )

--- a/hum/pyo_util.py
+++ b/hum/pyo_util.py
@@ -723,6 +723,13 @@ class Synth(MutableMapping):
         self._server = None
         self.output = None
         self._synth_func_params = synth_func_defaults(synth_func)
+        # `_synth_func_params` is *live state*, not a record of the defaults:
+        # `_rebuild_graph` writes the current values into it, and the initial
+        # `Knobs` below shares the very dict object. So it cannot answer "what
+        # does the synth function itself default to?" -- a question an offline
+        # render has to ask (see `render_events`). Keep a pristine copy that
+        # nothing mutates.
+        self._synth_func_defaults = dict(self._synth_func_params)
 
         assert value_trans is None or (
             isinstance(value_trans, Mapping)
@@ -998,12 +1005,17 @@ class Synth(MutableMapping):
         Only *dials* are driven by a live control signal (``SigTo``). *Settings* --
         the structural parameters that require a graph rebuild -- are baked into
         the single render graph from the recording's initial snapshot, falling
-        back to the synth function's own defaults for settings the recording
-        never mentions. Wrapping a setting in a ``SigTo`` (as this method used to
-        do for every recorded key) hands the synth function a signal object where
-        it expected a plain value, which breaks any synth that uses a setting as
-        a dict key (``TypeError: unhashable type: 'SigTo'``) and silently
-        misbehaves in one that merely compares it.
+        back to the synth function's own defaults (``_synth_func_defaults``, the
+        pristine copy -- *not* the live ``_synth_func_params``, which tracks the
+        current session state) for settings the recording never mentions.
+        Rendering is therefore a pure function of the event stream: the same
+        stream renders identically on a fresh and on a long-used ``Synth``.
+
+        Wrapping a setting in a ``SigTo`` (as this method used to do for every
+        recorded key) hands the synth function a signal object where it expected
+        a plain value, which breaks any synth that uses a setting as a dict key
+        (``TypeError: unhashable type: 'SigTo'``) and silently misbehaves in one
+        that merely compares it.
 
         A settings change *later* in the stream is dropped with a
         :class:`hum.event_params.RenderParamWarning`: a single offline render
@@ -1030,7 +1042,7 @@ class Synth(MutableMapping):
             control_events,
             dials=self._dials,
             settings=self._settings,
-            settings_defaults=self._synth_func_params,
+            settings_defaults=self._synth_func_defaults,
         )
         raw_params = {k: SigTo(value=0, time=0.01) for k in plan.dial_keys}
         synth_output = self._synth_func(**raw_params, **plan.settings_values).out()

--- a/hum/pyo_util.py
+++ b/hum/pyo_util.py
@@ -21,6 +21,7 @@ from collections.abc import MutableMapping
 import time
 
 from hum.util import round_numbers
+from hum.event_params import plan_render_params
 
 from pyo import PyoObject
 from pyo import *  # TODO: change to be explicit object imports
@@ -992,7 +993,25 @@ class Synth(MutableMapping):
         file_format="wav",
         suffix_buffer_seconds=0.0,
     ):
-        """Render the control events to an audio file or return it via an egress function."""
+        """Render the control events to an audio file or return it via an egress function.
+
+        Only *dials* are driven by a live control signal (``SigTo``). *Settings* --
+        the structural parameters that require a graph rebuild -- are baked into
+        the single render graph from the recording's initial snapshot, falling
+        back to the synth function's own defaults for settings the recording
+        never mentions. Wrapping a setting in a ``SigTo`` (as this method used to
+        do for every recorded key) hands the synth function a signal object where
+        it expected a plain value, which breaks any synth that uses a setting as
+        a dict key (``TypeError: unhashable type: 'SigTo'``) and silently
+        misbehaves in one that merely compares it.
+
+        A settings change *later* in the stream is dropped with a
+        :class:`hum.event_params.RenderParamWarning`: a single offline render
+        builds one graph, so it cannot express the rebuild that the live path
+        performs via ``_rebuild_graph``. Split the recording and render each
+        segment separately if you need the change. Dropped events keep their slot
+        in the stream, so render timing is unaffected.
+        """
         if not control_events:
             control_events = self.get_recording()
             if not control_events:
@@ -1007,17 +1026,26 @@ class Synth(MutableMapping):
         server = Server(**offline_server_kwargs).boot()
         table = NewTable(length=total_duration)
 
-        all_keys = {k for _, knobs in control_events for k in knobs}
-        raw_params = {k: SigTo(value=0, time=0.01) for k in all_keys}
-        synth_output = self._synth_func(**raw_params).out()
+        plan = plan_render_params(
+            control_events,
+            dials=self._dials,
+            settings=self._settings,
+            settings_defaults=self._synth_func_params,
+        )
+        raw_params = {k: SigTo(value=0, time=0.01) for k in plan.dial_keys}
+        synth_output = self._synth_func(**raw_params, **plan.settings_values).out()
         table_recorder = TableRec(synth_output, table=table).play()
 
         def delay_func(dur):
             server.recordOptions(dur=dur)
             server.start()
 
+        # Drive dials only: `_apply_event_sequence` looks every key up in
+        # `raw_params`, which is now dial-only, so a settings key would KeyError.
+        dial_events = [(t - base_time, knobs) for t, knobs in plan.dial_events]
+
         try:
-            self._apply_event_sequence(normalized, delay_func, raw_params=raw_params)
+            self._apply_event_sequence(dial_events, delay_func, raw_params=raw_params)
         finally:
             table_recorder.stop()
 

--- a/hum/tests/conftest.py
+++ b/hum/tests/conftest.py
@@ -1,0 +1,111 @@
+"""Shared test fixtures: import ``hum.pyo_util`` with or without a real ``pyo``.
+
+The audio engine ``pyo`` is an optional extra (``pip install hum[audio]``) and is
+absent from CI, yet the pure logic in ``hum.pyo_util`` (recording, event
+partitioning, event replay) is worth gating there. So when pyo is missing we
+inject a minimal fake just long enough to import the module, then clean it up so
+``test_import_safety`` still observes a pristine, pyo-free environment.
+
+The fake mirrors the two real behaviours these tests depend on:
+
+- ``SigTo`` is **unhashable** (like ``pyo.SigTo``, which defines ``__eq__`` for
+  signal arithmetic and so gets ``__hash__ = None``). That is what turns a
+  SigTo-wrapped *setting* into ``TypeError: unhashable type: 'SigTo'`` inside a
+  synth function that uses the setting as a dict key (issue #7).
+- ``NewTable.save`` writes a real file, since ``render_events`` reads it back.
+"""
+
+import importlib
+import importlib.machinery
+import importlib.util
+import sys
+import types
+
+import pytest
+
+HAS_PYO = importlib.util.find_spec("pyo") is not None
+
+
+def make_fake_pyo_module():
+    """A minimal stand-in for pyo: the names ``hum.pyo_util`` needs."""
+    fake_pyo = types.ModuleType("pyo")
+    # A real spec so importlib.util.find_spec("pyo") keeps working on this fake.
+    fake_pyo.__spec__ = importlib.machinery.ModuleSpec("pyo", loader=None)
+
+    class PyoObject:
+        pass
+
+    class SigTo(PyoObject):
+        def __init__(self, value=0, time=0.025, init=None, mul=1, add=0):
+            self.value, self.time, self.mul, self.add = value, time, mul, add
+
+        def __eq__(self, other):  # pragma: no cover - shape, not behaviour
+            return NotImplemented
+
+        # Defining __eq__ drops __hash__; real pyo signals are unhashable too.
+        __hash__ = None
+
+    class Server:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def boot(self):
+            return self
+
+        def start(self):
+            return self
+
+        def stop(self):
+            return self
+
+        def shutdown(self):
+            return self
+
+        def recordOptions(self, **kwargs):
+            return self
+
+    class NewTable:
+        def __init__(self, length=0, **kwargs):
+            self.length = length
+
+        def save(self, path, *args, **kwargs):
+            with open(path, "wb") as f:
+                f.write(b"fake-audio")
+
+    class TableRec:
+        def __init__(self, obj, table=None, **kwargs):
+            self.obj, self.table = obj, table
+
+        def play(self):
+            return self
+
+        def stop(self):
+            return self
+
+    fake_pyo.PyoObject = PyoObject
+    fake_pyo.SigTo = SigTo
+    fake_pyo.Server = Server
+    fake_pyo.NewTable = NewTable
+    fake_pyo.TableRec = TableRec
+    return fake_pyo
+
+
+@pytest.fixture(scope="module")
+def pyo_util():
+    """Import hum.pyo_util -- with real pyo when available, else a minimal fake."""
+    if HAS_PYO:
+        yield importlib.import_module("hum.pyo_util")
+        return
+
+    # No pyo installed (the CI case): inject a fake, import, then clean up so
+    # other tests (notably test_import_safety) see the pristine environment.
+    sys.modules["pyo"] = make_fake_pyo_module()
+    try:
+        yield importlib.import_module("hum.pyo_util")
+    finally:
+        sys.modules.pop("pyo", None)
+        sys.modules.pop("hum.pyo_util", None)
+        import hum
+
+        if hasattr(hum, "pyo_util"):
+            delattr(hum, "pyo_util")

--- a/hum/tests/conftest.py
+++ b/hum/tests/conftest.py
@@ -13,6 +13,19 @@ The fake mirrors the two real behaviours these tests depend on:
   SigTo-wrapped *setting* into ``TypeError: unhashable type: 'SigTo'`` inside a
   synth function that uses the setting as a dict key (issue #7).
 - ``NewTable.save`` writes a real file, since ``render_events`` reads it back.
+
+Two fixtures, and the difference matters:
+
+- :func:`pyo_util` uses the **real** engine when it is installed. Use it for
+  tests that only need the module's pure logic, so they exercise the real thing
+  where they can.
+- :func:`fake_pyo_util` **always** uses the fake. Use it for any test that
+  *drives* the synthesis graph (``render_events``), because the fake's stand-in
+  output object is not a real ``PyoObject``: ``pyo.TableRec`` type-checks its
+  input (``pyoArgsAssert(self, "otn", ...)``) and rejects it. Such a test would
+  pass in CI, where there is no pyo, and fail on a developer machine that ran
+  the documented full-verify command ``pip install -e ".[audio]"`` -- the worst
+  kind of failure, since CI can never see it.
 """
 
 import importlib
@@ -20,6 +33,7 @@ import importlib.machinery
 import importlib.util
 import sys
 import types
+from contextlib import contextmanager
 
 import pytest
 
@@ -90,6 +104,40 @@ def make_fake_pyo_module():
     return fake_pyo
 
 
+def _restore_hum_pyo_util_attribute(module):
+    """Keep the ``hum.pyo_util`` *attribute* consistent with ``sys.modules``.
+
+    Importing a submodule sets it as an attribute of its package, so undoing an
+    import means undoing that too -- otherwise ``test_import_safety`` observes a
+    ``hum`` that has already reached into the audio engine.
+    """
+    import hum
+
+    if module is not None:
+        hum.pyo_util = module
+    elif "pyo_util" in vars(hum):
+        delattr(hum, "pyo_util")
+
+
+@contextmanager
+def _pyo_util_backed_by_fake():
+    """Import ``hum.pyo_util`` against a fake ``pyo``, then restore the environment."""
+    saved = {
+        name: sys.modules[name]
+        for name in ("pyo", "hum.pyo_util")
+        if name in sys.modules
+    }
+    sys.modules["pyo"] = make_fake_pyo_module()
+    sys.modules.pop("hum.pyo_util", None)
+    try:
+        yield importlib.import_module("hum.pyo_util")
+    finally:
+        sys.modules.pop("pyo", None)
+        sys.modules.pop("hum.pyo_util", None)
+        sys.modules.update(saved)
+        _restore_hum_pyo_util_attribute(saved.get("hum.pyo_util"))
+
+
 @pytest.fixture(scope="module")
 def pyo_util():
     """Import hum.pyo_util -- with real pyo when available, else a minimal fake."""
@@ -99,13 +147,16 @@ def pyo_util():
 
     # No pyo installed (the CI case): inject a fake, import, then clean up so
     # other tests (notably test_import_safety) see the pristine environment.
-    sys.modules["pyo"] = make_fake_pyo_module()
-    try:
-        yield importlib.import_module("hum.pyo_util")
-    finally:
-        sys.modules.pop("pyo", None)
-        sys.modules.pop("hum.pyo_util", None)
-        import hum
+    with _pyo_util_backed_by_fake() as module:
+        yield module
 
-        if hasattr(hum, "pyo_util"):
-            delattr(hum, "pyo_util")
+
+@pytest.fixture
+def fake_pyo_util():
+    """Import hum.pyo_util against the fake pyo, *even when real pyo is installed*.
+
+    For tests that drive the synthesis graph rather than just its pure logic --
+    see this module's docstring for why the real engine cannot serve them.
+    """
+    with _pyo_util_backed_by_fake() as module:
+        yield module

--- a/hum/tests/test_event_recording.py
+++ b/hum/tests/test_event_recording.py
@@ -11,76 +11,13 @@ milliseconds later), yielding near-duplicate events like::
     (2.0084, {'waveform': 'triangle'}),   # <-- duplicate
 
 These tests run fully headless: no pyo server is booted and no real pyo
-objects are created. When pyo is not installed at all (e.g. CI), a minimal
-fake ``pyo`` module is injected just for this module, then cleaned up so the
-import-safety tests still observe the real no-pyo environment.
+objects are created. When pyo is not installed at all (e.g. CI), the shared
+``pyo_util`` fixture (see ``conftest.py``) injects a minimal fake ``pyo``
+module, then cleans it up so the import-safety tests still observe the real
+no-pyo environment.
 """
 
-import importlib
-import importlib.machinery
-import importlib.util
-import sys
-import types
-
 import pytest
-
-HAS_PYO = importlib.util.find_spec("pyo") is not None
-
-
-def _make_fake_pyo_module():
-    """A minimal stand-in for pyo: just the names hum.pyo_util needs at import."""
-    fake_pyo = types.ModuleType("pyo")
-    # A real spec so importlib.util.find_spec("pyo") keeps working on this fake.
-    fake_pyo.__spec__ = importlib.machinery.ModuleSpec("pyo", loader=None)
-
-    class PyoObject:
-        pass
-
-    class SigTo(PyoObject):
-        def __init__(self, value=0, time=0.025, init=None, mul=1, add=0):
-            self.value, self.time, self.mul, self.add = value, time, mul, add
-
-    class Server:
-        def __init__(self, *args, **kwargs):
-            pass
-
-        def boot(self):
-            return self
-
-        def start(self):
-            return self
-
-        def stop(self):
-            return self
-
-        def shutdown(self):
-            return self
-
-    fake_pyo.PyoObject = PyoObject
-    fake_pyo.SigTo = SigTo
-    fake_pyo.Server = Server
-    return fake_pyo
-
-
-@pytest.fixture(scope="module")
-def pyo_util():
-    """Import hum.pyo_util — with real pyo when available, else a minimal fake."""
-    if HAS_PYO:
-        yield importlib.import_module("hum.pyo_util")
-        return
-
-    # No pyo installed (the CI case): inject a fake, import, then clean up so
-    # other tests (notably test_import_safety) see the pristine environment.
-    sys.modules["pyo"] = _make_fake_pyo_module()
-    try:
-        yield importlib.import_module("hum.pyo_util")
-    finally:
-        sys.modules.pop("pyo", None)
-        sys.modules.pop("hum.pyo_util", None)
-        import hum
-
-        if hasattr(hum, "pyo_util"):
-            delattr(hum, "pyo_util")
 
 
 @pytest.fixture

--- a/hum/tests/test_render_events_params.py
+++ b/hum/tests/test_render_events_params.py
@@ -1,0 +1,187 @@
+"""Regression tests for the dial/settings split on render (issue #7).
+
+``Synth.render_events`` used to build its live control signals from *every*
+recorded key::
+
+    all_keys = {k for _, knobs in control_events for k in knobs}
+    raw_params = {k: SigTo(value=0, time=0.01) for k in all_keys}
+
+A recording's first event is a full snapshot of the synth state, so it always
+mentions the *settings* too. Every setting therefore reached the synth function
+as a ``SigTo`` instead of its plain value -- crashing any synth that uses a
+setting as a dict key with ``TypeError: unhashable type: 'SigTo'``, and silently
+misbehaving in one that merely compares it.
+
+The other half of the fix -- easy to miss -- is that the *event stream* handed to
+``_apply_event_sequence`` must be filtered too: it looks every key up in
+``raw_params``, which is now dial-only, so a settings key would ``KeyError``.
+
+The first group of tests below exercises the split logic directly through the
+pyo-free ``hum.event_params`` helper, so they run (and gate) in CI, where pyo is
+not installed. The second group drives ``render_events`` end to end against a
+fake pyo, reproducing the reported crash.
+"""
+
+import pytest
+
+from hum.event_params import RenderParamWarning, plan_render_params
+
+
+DIALS = {"freq", "amp"}
+SETTINGS = {"waveform", "n_voices"}
+DEFAULTS = {"freq": 440, "amp": 0.5, "waveform": "sine", "n_voices": 1}
+
+
+def _plan(control_events, **kwargs):
+    kwargs = dict(
+        dict(dials=DIALS, settings=SETTINGS, settings_defaults=DEFAULTS), **kwargs
+    )
+    return plan_render_params(control_events, **kwargs)
+
+
+# --- the split itself ----------------------------------------------------------------
+
+
+def test_settings_never_become_dials():
+    # The defect: `waveform` and `n_voices` were wrapped in a SigTo along with
+    # the dials, because the initial snapshot mentions every parameter.
+    plan = _plan([(0.0, dict(DEFAULTS)), (1.0, {"freq": 660})])
+    assert plan.dial_keys == frozenset({"freq", "amp"})
+    assert not (plan.dial_keys & SETTINGS)
+
+
+def test_settings_are_baked_from_the_initial_snapshot():
+    plan = _plan([(0.0, {"freq": 440, "waveform": "square", "n_voices": 3})])
+    assert plan.settings_values == {"n_voices": 3, "waveform": "square"}
+
+
+def test_settings_absent_from_the_recording_fall_back_to_defaults():
+    # A recording that mentions no setting at all still needs the synth built
+    # with its own defaults, not with SigTo-wrapped placeholders.
+    plan = _plan([(0.0, {"freq": 440}), (1.0, {"freq": 660})])
+    assert plan.settings_values == {"n_voices": 1, "waveform": "sine"}
+    assert plan.dial_keys == frozenset({"freq"})
+
+
+def test_a_dial_first_seen_mid_stream_is_still_driven():
+    plan = _plan([(0.0, {"freq": 440}), (1.0, {"amp": 0.9})])
+    assert plan.dial_keys == frozenset({"freq", "amp"})
+
+
+# --- the half that is easy to miss: the event stream must be filtered too -------------
+
+
+def test_events_handed_to_the_applier_carry_no_settings_key():
+    # `_apply_event_sequence` does `raw_params[key]`; raw_params is dial-only,
+    # so any surviving settings key would raise KeyError at render time.
+    events = [
+        (0.0, dict(DEFAULTS)),
+        (1.0, {"freq": 660, "waveform": "square"}),
+        (2.0, {"n_voices": 4}),
+    ]
+    with pytest.warns(RenderParamWarning):
+        plan = _plan(events)
+    surviving = {k for _, updates in plan.dial_events for k in updates}
+    assert not (surviving & SETTINGS)
+    assert surviving <= plan.dial_keys
+
+
+def test_a_mid_stream_settings_change_warns_rather_than_raising():
+    events = [(0.0, dict(DEFAULTS)), (1.0, {"waveform": "square"})]
+    with pytest.warns(RenderParamWarning, match="waveform"):
+        plan = _plan(events)
+    assert plan.ignored_settings_changes == [(1.0, {"waveform": "square"})]
+    # The initial snapshot's value is what gets baked, not the later one.
+    assert plan.settings_values["waveform"] == "sine"
+
+
+def test_settings_in_the_initial_snapshot_alone_do_not_warn(recwarn):
+    _plan([(0.0, dict(DEFAULTS)), (1.0, {"freq": 660})])
+    assert [w for w in recwarn.list if issubclass(w.category, RenderParamWarning)] == []
+
+
+def test_filtering_preserves_event_count_and_timestamps():
+    # Dropping events outright would shorten the render; each event keeps its
+    # slot (possibly empty) so the inter-event delays are unchanged.
+    events = [
+        (10.0, dict(DEFAULTS)),
+        (11.5, {"freq": 660}),
+        (13.0, {"waveform": "square"}),
+    ]
+    with pytest.warns(RenderParamWarning):
+        plan = _plan(events)
+    assert [t for t, _ in plan.dial_events] == [10.0, 11.5, 13.0]
+    assert plan.dial_events[-1] == (13.0, {})
+
+
+def test_keys_that_are_neither_dial_nor_setting_are_dropped_with_a_warning():
+    with pytest.warns(RenderParamWarning, match="mystery"):
+        plan = _plan([(0.0, {"freq": 440, "mystery": 1})])
+    assert plan.unknown_keys == frozenset({"mystery"})
+    assert plan.dial_keys == frozenset({"freq"})
+
+
+def test_empty_recording_is_handled():
+    plan = _plan([])
+    assert plan.dial_keys == frozenset()
+    assert plan.dial_events == []
+    assert plan.settings_values == dict(
+        n_voices=DEFAULTS["n_voices"], waveform=DEFAULTS["waveform"]
+    )
+
+
+# --- end to end through render_events ------------------------------------------------
+
+WAVEFORMS = {"sine": 0, "square": 1, "triangle": 2}
+
+
+@pytest.fixture
+def synth_and_calls(pyo_util):
+    """A Synth whose synth function uses its setting as a dict key (issue #7)."""
+    calls = []
+
+    class FakeOutput:
+        def out(self):
+            return self
+
+        def stop(self):
+            return self
+
+    def synth_func(freq=440, waveform="sine"):
+        # The reported crash: a SigTo-wrapped `waveform` is unhashable.
+        WAVEFORMS[waveform]
+        calls.append({"freq": freq, "waveform": waveform})
+        return FakeOutput()
+
+    return pyo_util.Synth(synth_func, dials="freq", settings="waveform"), calls
+
+
+def test_render_events_passes_settings_through_as_plain_values(
+    synth_and_calls, tmp_path
+):
+    synth, calls = synth_and_calls
+    events = [(0.0, {"freq": 440, "waveform": "square"}), (1.0, {"freq": 660})]
+
+    audio = synth.render_events(events, output_filepath=str(tmp_path / "out.wav"))
+
+    assert audio  # rendered without TypeError: unhashable type: 'SigTo'
+    (call,) = calls
+    assert call["waveform"] == "square"  # a plain string, not a SigTo
+    assert isinstance(call["waveform"], str)
+    assert type(call["freq"]).__name__ == "SigTo"  # the dial *is* driven
+
+
+def test_render_events_survives_a_mid_stream_settings_change(synth_and_calls, tmp_path):
+    # Before the fix's second half this raised KeyError('waveform') inside
+    # _apply_event_sequence, once raw_params became dial-only.
+    synth, calls = synth_and_calls
+    events = [
+        (0.0, {"freq": 440, "waveform": "sine"}),
+        (1.0, {"freq": 660, "waveform": "triangle"}),
+    ]
+
+    with pytest.warns(RenderParamWarning, match="waveform"):
+        audio = synth.render_events(events, output_filepath=str(tmp_path / "out.wav"))
+
+    assert audio
+    assert calls[0]["waveform"] == "sine"

--- a/hum/tests/test_render_events_params.py
+++ b/hum/tests/test_render_events_params.py
@@ -16,10 +16,16 @@ The other half of the fix -- easy to miss -- is that the *event stream* handed t
 ``_apply_event_sequence`` must be filtered too: it looks every key up in
 ``raw_params``, which is now dial-only, so a settings key would ``KeyError``.
 
+A third thing the split has to get right, found in review: the *fallback* for a
+setting the recording never mentions must be the synth function's own defaults,
+not ``Synth._synth_func_params`` -- which is live state that ``_rebuild_graph``
+overwrites with the current values. Using it made an offline render depend on
+what the session happened to do beforehand.
+
 The first group of tests below exercises the split logic directly through the
 pyo-free ``hum.event_params`` helper, so they run (and gate) in CI, where pyo is
-not installed. The second group drives ``render_events`` end to end against a
-fake pyo, reproducing the reported crash.
+not installed. The remaining groups drive ``render_events`` end to end against a
+fake pyo, reproducing the reported crash and pinning the fallback source.
 """
 
 import pytest
@@ -136,8 +142,17 @@ WAVEFORMS = {"sine": 0, "square": 1, "triangle": 2}
 
 
 @pytest.fixture
-def synth_and_calls(pyo_util):
-    """A Synth whose synth function uses its setting as a dict key (issue #7)."""
+def synth_factory(fake_pyo_util):
+    """Build Synths whose synth function uses its setting as a dict key (issue #7).
+
+    Uses ``fake_pyo_util``, not ``pyo_util``: these tests drive the render graph,
+    and a real ``pyo.TableRec`` rejects the fake output object below. See
+    ``conftest.py`` for the full reason.
+
+    Returns ``(make_synth, calls)`` -- a factory rather than a single instance,
+    because pinning the settings fallback needs a *fresh* Synth to compare a
+    *used* one against.
+    """
     calls = []
 
     class FakeOutput:
@@ -153,7 +168,17 @@ def synth_and_calls(pyo_util):
         calls.append({"freq": freq, "waveform": waveform})
         return FakeOutput()
 
-    return pyo_util.Synth(synth_func, dials="freq", settings="waveform"), calls
+    def make_synth():
+        return fake_pyo_util.Synth(synth_func, dials="freq", settings="waveform")
+
+    return make_synth, calls
+
+
+@pytest.fixture
+def synth_and_calls(synth_factory):
+    """A single fresh Synth from :func:`synth_factory`, plus its call log."""
+    make_synth, calls = synth_factory
+    return make_synth(), calls
 
 
 def test_render_events_passes_settings_through_as_plain_values(
@@ -185,3 +210,47 @@ def test_render_events_survives_a_mid_stream_settings_change(synth_and_calls, tm
 
     assert audio
     assert calls[0]["waveform"] == "sine"
+
+
+# --- the settings fallback must be the function's defaults, not the live state --------
+
+
+def test_the_synth_functions_defaults_survive_a_live_settings_change(synth_factory):
+    # `_synth_func_params` is live state -- `_rebuild_graph` writes the current
+    # values into it, and the initial `Knobs` shares the very dict object. The
+    # defaults a render falls back to must be a separate, pristine copy.
+    make_synth, _ = synth_factory
+    synth = make_synth()
+    defaults_before = dict(synth._synth_func_defaults)
+
+    synth.update({"waveform": "square"})  # a settings change -> _rebuild_graph
+
+    assert synth._synth_func_params["waveform"] == "square"  # live state moved
+    assert synth._synth_func_defaults == defaults_before  # the defaults did not
+    assert synth._synth_func_defaults["waveform"] == "sine"
+
+
+def test_render_of_a_dial_only_stream_does_not_depend_on_session_history(
+    synth_factory, tmp_path
+):
+    # Rendering must be a pure function of the event stream. Falling back to
+    # `_synth_func_params` baked whatever the session last happened to be set
+    # to, so a dial-only stream (exactly what a client that pre-filters its
+    # events sends) rendered 'square' on a used Synth and 'sine' on a fresh one
+    # -- silently, and with no way to reproduce it from the events alone.
+    make_synth, calls = synth_factory
+    dial_only_events = [(0.0, {"freq": 440}), (1.0, {"freq": 660})]
+
+    used = make_synth()
+    used.update({"waveform": "square"})  # a live settings change, then reuse
+    calls.clear()
+    used.render_events(dial_only_events, output_filepath=str(tmp_path / "used.wav"))
+    waveform_from_used = calls[-1]["waveform"]
+
+    calls.clear()
+    fresh = make_synth()
+    fresh.render_events(dial_only_events, output_filepath=str(tmp_path / "fresh.wav"))
+    waveform_from_fresh = calls[-1]["waveform"]
+
+    assert waveform_from_used == waveform_from_fresh
+    assert waveform_from_used == "sine"  # the synth function's own default


### PR DESCRIPTION
Closes #7

## The defect

`Synth.render_events` built its live control signals from **every** recorded key:

```python
all_keys = {k for _, knobs in control_events for k in knobs}
raw_params = {k: SigTo(value=0, time=0.01) for k in all_keys}
synth_output = self._synth_func(**raw_params).out()
```

A recording's first event is a full snapshot of the synth state, so it *always*
mentions the settings too. Every setting therefore reached the synth function as
a `SigTo` instead of its plain value. A synth that uses a setting as a dict key
crashed with `TypeError: unhashable type: 'SigTo'` (`SigTo` defines `__eq__`
without `__hash__`); one that merely compares it misbehaved silently.

## The fix

Dials and settings were already resolved and stored on the `Synth`
(`self._dials` / `self._settings`), so the split just had to be used:

- **Dials** mentioned by the recording get a `SigTo`.
- **Settings** are baked into the single render graph from the recording's
  initial snapshot, falling back to the synth function's own defaults for
  settings the recording never mentions.

### The half that is easy to miss

The event stream handed to `_apply_event_sequence` had to be filtered too. That
method does `target = raw_params[key]`, and `raw_params` is now dial-only — so
any surviving settings key raises `KeyError`. Fixing only the first half swaps
one crash for another. (Mutation 2 below demonstrates exactly that.)

A settings change *after* the initial snapshot is dropped with a warning rather
than raising: a single offline render builds one graph, so it cannot express the
rebuild that the live path performs via `_rebuild_graph`. This conservative
default — bake the initial snapshot, warn and ignore later changes — mirrors what
the online path already does, so it needs no maintainer decision. Documented in
the `render_events` docstring. Filtered events **keep their slot** (possibly with
an empty update dict) so inter-event delays, and therefore render timing, are
unchanged.

## Why a new module

`hum/pyo_util.py` imports `pyo` at module scope, and hum's CI has no `pyo`, so
`hum/tests/test_pyo_synth.py` is skipped wholesale at collection. **A test that
only runs with pyo installed is not a gate.**

So the split logic lives in a new, pyo-free `hum/event_params.py`
(`plan_render_params` → `RenderParamPlan`). It is a better home for it anyway:
the dial/settings partition is a property of the `Synth` parameter model, not of
the audio engine. The 10 tests that exercise it import it directly and run
everywhere.

The fake-pyo fixture that `test_event_recording.py` introduced for #5 is lifted
into a shared `hum/tests/conftest.py` (one definition instead of two) and
extended with `NewTable`, `TableRec` and an **unhashable** `SigTo`, which lets 4
further tests drive `render_events` end to end headlessly and reproduce the
reported crash faithfully.

---

## Review follow-up (second commit)

An adversarial review found two real defects in the first commit. Both are fixed
here, and both were confirmed by *running* them before and after.

### 1. The settings fallback was history-dependent

The fallback source was `self._synth_func_params`. That attribute is **live
state**, not a record of the defaults: `_rebuild_graph` writes the current
values into it (`self._synth_func_params.update(merged_params)`), and the
initial `Knobs` is constructed *around the very dict object*
(`Knobs.__init__` does `self._params = param_dict`, no copy) so its non-SigTo
writes land there too.

So `render_events` baked whatever the session last happened to be set to, not
"the synth function's own defaults" as the docstring and the original PR body
both claimed. Reproduced with the fake-pyo harness:

```
pristine defaults:                          {'freq': 440, 'waveform': 'sine'}
_synth_func_params before:                  {'freq': 440, 'waveform': 'sine'}
_synth_func_params after s.update({'waveform': 'square'}):
                                            {'freq': 440, 'waveform': 'square'}

render [(0.0, {'freq': 440}), (1.0, {'freq': 660})]   # a dial-only stream
  on the USED  synth -> waveform = square
  on a  FRESH  synth -> waveform = sine
```

Same event stream, different audio, silently, with no way to reproduce it from
the events. And *worse than before this PR*: pre-fix that path passed no setting
at all, so the signature default applied deterministically. The split introduced
the history dependence.

**Fix:** `Synth.__init__` now also keeps `self._synth_func_defaults`, a pristine
copy that nothing mutates, and `render_events` falls back to that. Rendering is
again a pure function of the event stream. The comment at the assignment says
why the two attributes must not be re-conflated.

### 2. The two end-to-end tests broke when the `audio` extra *was* installed

They took the shared `pyo_util` fixture, which yields the **real**
`hum.pyo_util` whenever pyo is importable. `render_events` then hands the
fixture's stand-in output object to a real `pyo.TableRec`, whose
`__init__` opens with an unconditional `pyoArgsAssert(self, "otn", ...)`; format
`'o'` requires `isAudioObject(arg)`, which the stand-in is not. CI is pyo-free
and can never catch this — but the repo's documented full-verify command is
`pip install -e ".[audio]" && python -m pytest hum/`.

**Fix:** `conftest.py` gains a `fake_pyo_util` fixture that injects the fake
**regardless** of whether real pyo is installed, and restores `sys.modules` and
the `hum.pyo_util` package attribute afterwards. The graph-driving tests use it;
the pyo-free helper tests are unchanged. Verified against a stand-in pyo whose
`TableRec` type-checks the way the real one does:

```
world: real(strict) pyo installed; hum.pyo_util imported against it
OLD wiring (real pyo): FAILED -> TypeError: PyoArgumentTypeError: 'o' argument must be a PyoObject
NEW wiring (fake_pyo_util): PASSED, waveform='square'
restoration: OK (pyo, hum.pyo_util module + attribute all back)
```

The import-safety tests still see a pristine, pyo-free environment — checked in
**both** collection orders (`test_render_events_params.py` before *and* after
`test_import_safety.py`).

## Verification

Real gate, run locally in an environment with **no pyo installed** — the same
shape as CI (`--doctest-modules`, `testpaths = ["tests", "hum/tests"]`, the
`exclude_paths` ignores from `[tool.wads.ci.testing]`):

```
$ python -m pytest --doctest-modules -o doctest_optionflags='ELLIPSIS IGNORE_EXCEPTION_DETAIL' \
    --ignore=examples --ignore=scrap --ignore=docsrc --ignore=hum/scrap \
    --ignore=hum/pyo_util.py --ignore=hum/pyo_synths.py --ignore=hum/synth_funcs.py \
    --ignore=hum/pyo_util_examples.py -q --tb=short

======================== 23 passed, 2 skipped in 0.62s =========================
```

Master's baseline was 9 passed / 2 skipped; all 14 new tests are **collected and
run without pyo**, confirming they gate. `ruff format --check hum/` reports
`11 files already formatted`, holding master's invariant. `ruff check .` reports
only the pre-existing `docsrc/conf.py` D100 (confirmed pre-existing by stashing
this branch's changes and re-running).

### Mutation testing

Every regression test here was mutation-tested: the bug it guards was
deliberately reintroduced and the suite confirmed to **fail**.

| # | Reverted to | Result |
|---|---|---|
| 1 | `dial_keys = recorded_keys` (drop the `& dials` intersection) — the reported defect | **6 failed**, incl. `test_settings_never_become_dials` and both end-to-end tests |
| 2 | `dial_events = [(t, dict(updates)) ...]` (no filtering) — the half that is easy to miss | **2 failed** with `KeyError: 'waveform'` inside `_apply_event_sequence` |
| 3 | `render_events` restored verbatim to the pre-fix three lines | **2 failed** with `TypeError: unhashable type: 'SigTo'` — the exact error from the issue |
| 4 | `settings_defaults=self._synth_func_params` (the review finding) | **1 failed**: `test_render_of_a_dial_only_stream_does_not_depend_on_session_history`, `assert 'square' == 'sine'` |
| 5 | `self._synth_func_defaults = self._synth_func_params` (alias, not a copy) | **2 failed**: the above plus `test_the_synth_functions_defaults_survive_a_live_settings_change` |

Row 2 read "4 failed, 16 passed" in the original body. That was a miscount —
re-measured it is 2 failed / 19 passed (and 4 + 16 = 20 never summed to the 21
items collected at the time). The mutation does gate; only the bookkeeping was
wrong.

Files were diffed against backups afterwards to confirm a clean restore, and the
full suite re-run green.

#### One mutation that provably cannot be caught

The review suggested "a test that fails when the `settings_defaults=` argument
is removed". **No such test can exist**, and this is a semantic identity rather
than a gap in coverage:

- `_resolve_dials_and_settings` raises `ValueError: Unknown parameters specified`
  for any setting that is not a parameter of the synth function, and
  `synth_func_defaults` raises for any parameter without a default. So **every
  setting is a synth-function parameter that has a default.**
- For any `f(waveform="sine")`, `f()` and `f(waveform="sine")` are
  indistinguishable from inside `f`. Removing `settings_defaults=` therefore
  produces exactly the same call — measured: `23 passed, 2 skipped`.

What *is* observable, and what the tests pin, is which values the fallback
supplies when they differ from the function's own defaults — which is precisely
the bug (rows 4 and 5). The argument is kept rather than deleted because
`RenderParamPlan.settings_values` is documented as "settings values baked into
the graph at build time"; without the fallback that field would list only the
settings the recording mentioned, and so would no longer describe the graph
actually built.

## Blast radius

`hum` is published on PyPI, so **external callers of `Synth.render_events` are
affected** — for them this is a straight bug fix: settings now arrive as the
plain values their synth functions declare. Behaviour changes worth naming:

- Settings are now passed to the synth function on render (previously they were
  passed, but SigTo-wrapped).
- Mid-stream settings changes are now ignored with a `RenderParamWarning`
  instead of being applied as a meaningless `SigTo.value` assignment.
- Recorded keys that are neither a dial nor a setting are dropped with a warning
  instead of raising `TypeError` from the synth function call.
- `Synth` gains a private `_synth_func_defaults` attribute. No public surface
  changes.

`theremin` is the only local dependent; it has its own client-side filter landing
separately. That filter stays valid — a pre-filtered dial-only stream simply
produces no warning here, and (as of the review follow-up) also renders the same
settings whatever the session did beforehand.

https://claude.ai/code/session_01GPpn5ixPgqGqk7uJH7cC6o
